### PR TITLE
Add support for DS1822P sensor, resolve #1.

### DIFF
--- a/ds18x20.py
+++ b/ds18x20.py
@@ -29,8 +29,16 @@ while True:
 
 class DS18X20(object):
     def __init__(self, onewire):
+        """
+        1-Wire family codes:
+        - DS18S20: 10h
+        - DS1822P: 22h
+        - DS18B20: 28h
+
+        http://owfs.sourceforge.net/family.html
+        """
         self.ow = onewire
-        self.roms = [rom for rom in self.ow.scan() if rom[0] == 0x10 or rom[0] == 0x28]
+        self.roms = [rom for rom in self.ow.scan() if rom[0] in (0x10, 0x22, 0x28)]
         try:
             1/1
             self.fp = True


### PR DESCRIPTION
DS1822P sensors behave just like the DS18B20 except for the following:
- it has a different family code: 0x22
- it has only the GND and DQ pins connected, it uses parasitic power
  from the data line.

This is coming from https://github.com/micropython/micropython/commit/59543878.
Thanks, @dpgeorge.