### PR TITLE
DS18B20: Mask power-on reset value 0550h

### DIFF
--- a/ds18x20.py
+++ b/ds18x20.py
@@ -102,6 +102,9 @@ class DS18X20(object):
                 return 100 * temp_read - 25 + (count_per_c - count_remain) // count_per_c
         elif rom0 == 0x28:
             temp = None
+            # Mask power-on reset value 0550h (85°C)
+            if temp_msb == 0x05 and temp_lsb == 0x50:
+                return None
             if self.fp:
                 temp = (temp_msb << 8 | temp_lsb) / 16
             else:


### PR DESCRIPTION
According to the specification [1], the power-on reset value of 
the temperature register is +85°C (Page 6).

Resolve #7.

[1] https://datasheets.maximintegrated.com/en/ds/DS18B20.pdf