### PR TITLE
Make checking power mode optional

### DIFF
--- a/ds18x20.py
+++ b/ds18x20.py
@@ -12,6 +12,8 @@ class DS18X20:
     def __init__(self, onewire):
         self.ow = onewire
         self.buf = bytearray(9)
+
+    def read_power_supply()
         self.ow.writebyte(self.ow.CMD_SKIPROM)
         self.ow.writebyte(CMD_RDPOWER)
         self.powermode = self.ow.readbit()


### PR DESCRIPTION
This commit makes the DS18X20 driver not communicate with the hardware from within the object constructor when checking for the power mode.