### PR TITLE
Add convenience adapter class for reading a single DS18X20 sensor

### DIFF
--- a/ds18x20_single.py
+++ b/ds18x20_single.py
@@ -1,0 +1,20 @@
+# DS18x20 temperature sensor driver for MicroPython.
+# MIT license; Copyright (c) 2018 Robert Hammelrath
+#
+# Convenience adapter class for reading a single
+# DS18X20 temperature sensor attached to the 1-Wire bus.
+#
+from ds18x20 import DS18X20
+
+
+class DS18X20Single(DS18X20):
+
+    def convert_temp(self, rom=None):
+        if rom is None and len(self.roms) == 1:
+            rom = self.roms[0]
+        return super().convert_temp(rom)
+
+    def read_temp(self, rom=None):
+        if rom is None and len(self.roms) == 1:
+            rom = self.roms[0]
+        return super().read_temp(rom)


### PR DESCRIPTION
Dear Robert,

this reimplements some bits of your original improved driver from https://github.com/pycom/pycom-libraries/pull/62 using a minimal adapter class.

This might resolve #11 in a non-intrusive way. It separates concerns and by adding it through a distinct file, the code can be optionally imported by anyone who needs this feature.

If you still like to see that convenience feature, you might want to have this available. If not, feel free to close the PR right away.

With kind regards,
Andreas.