### PR TITLE
Add package.json for MIP compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "urls": [
+    ["ds18x20.py", "github:robert-hh/Onewire_DS18X20/ds18x20.py"],
+    ["onewire.py", "github:robert-hh/Onewire_DS18X20/onewire.py"],
+    ["ds18x20_single.py", "github:robert-hh/Onewire_DS18X20/ds18x20_single.py"]
+  ],
+  "version": "1.0.0",
+  "deps": []
+}


### PR DESCRIPTION
This PR adds a package.json file to make the module compatible with the MicroPython Package Manager (MIP).

With this change, users can install the module using: \

This PR is part of an effort to add package.json to popular MicroPython libraries.